### PR TITLE
Divider Short Variation

### DIFF
--- a/app/components/divider/schema.yml
+++ b/app/components/divider/schema.yml
@@ -1,5 +1,5 @@
 _description: |
-  A simple divider component.
+  A simple divider between other components. Can provide an optional title for the divider.
 
 title:
   _label: Divider Title

--- a/app/components/divider/template.hbs
+++ b/app/components/divider/template.hbs
@@ -1,5 +1,8 @@
-<div class="divider" data-uri="{{ default _ref self }}" data-editable="title">
-  {{#if title}}
-    <h2 class="title">{{ title }}</h2>
+<div class="divider {{ componentVariation }}" data-uri="{{ default _ref self }}">
+  {{!-- Check that we're dealing with the base variation --}}
+  {{#if (compare componentVariation "===" "divider")}}
+    {{#ifAny title @root.locals.edit}}
+      <h2 class="title" data-editable="title">{{ title }}</h2>
+    {{/ifAny}}
   {{/if}}
 </div>

--- a/app/styleguides/_default/components/divider.css
+++ b/app/styleguides/_default/components/divider.css
@@ -1,45 +1,7 @@
+$divider_color: #767676;
+
 .divider {
+  border-top: 1px solid $divider_color;
   margin: 0 0 20px;
   width: 100%;
-}
-
-.divider.component-selector-wrapper {
-  padding: 5px 0 0;
-}
-
-.divider.has-title {
-  height: auto;
-  position: relative;
-
-  .divider-title {
-    align-items: center;
-    background-color: #fff;
-    color: #333;
-    display: inline-flex;
-    font: italic 700 16px/15px Georgia, serif;
-    margin: 0;
-    width: 100%;
-    word-wrap: break-word;
-
-    span {
-      max-width: 85%;
-    }
-
-    &:after {
-      border-bottom: 1px solid #bdbdbd;
-      content: '';
-      flex: 5 0 15%;
-      height: calc(50% + 2px);
-      margin: 0 0 0 15px;
-      width: 100%;
-    }
-
-    @media screen and (min-width:600px) {
-      font: italic 700 20px/1.1 Georgia, serif;
-    }
-  }
-}
-
-.divider:not(.has-title) {
-  border-top: 1px solid #bdbdbd;
 }

--- a/app/styleguides/_default/components/divider_short.css
+++ b/app/styleguides/_default/components/divider_short.css
@@ -1,0 +1,9 @@
+@import '_default/components/divider.css';
+
+.divider.divider_short {
+  border-top-width: 5px;
+  height: 30px; /* if we use height to replace margin it becomes easier to click in edit mode */
+  margin: 25px 0 0;
+  max-width: 72px;
+  width: 12%;
+}


### PR DESCRIPTION
Gives the short divider a "short" variation

A big chunk of CSS was deleted because it was in the NYMag base instance and we can get rid of it.

The option to add a title has been removed when using the short variation 