### PR TITLE
Provide the absolute path to the environment properties file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Documentation around Clay is being refined in cojunction with iteration on this 
 
 Clone the repo and run the following commands:
 
-- `cp .env.sample .env` (This will create a file with the required env variables)
+- `cp app/.env.sample app/.env` (This will create a file with the required env variables)
 - `make` (This will download the containers, run an `npm install` and start the app)
 - `make add-access-key` ([Please read this doc for more information about your Clay access key](docs/clay-access-key.md))
 - `make bootstrap` (This command seeds some starting data)


### PR DESCRIPTION
Provide the absolute path to the environment properties file.  This will help users who are unfamiliar with the code to find the exact location of the .env.sample file.