### PR TITLE
Fix the response header so that it sets the Kiln pkg version correctly.

### DIFF
--- a/app/services/startup/index.js
+++ b/app/services/startup/index.js
@@ -40,9 +40,11 @@ function setupApp(app) {
   app.use(function(req, res, next) {
     res.set(
       'X-Powered-By',
-      [`clay v ${pkg.version}`, `amphora v ${amphoraPkg.version}`, `kiln v ${kilnPkg.versio}`].join(
-        '; '
-      )
+      [
+        `clay v ${pkg.version}`,
+        `amphora v ${amphoraPkg.version}`,
+        `kiln v ${kilnPkg.version}`
+      ].join('; ')
     );
     next();
   });


### PR DESCRIPTION
Hey noticed that the Kiln pkg version didn't display in the response headers so I fixed it.
I've also tested the solution.  Now it works with this pull request: X-Powered-By: clay v 0.0.1; amphora v 7.5.2; kiln v 8.5.0.  Linting also passed as shown below:
MATL2232LRCOMBS:app rcombs$ npm run lint-js && npm run lint-css

> clay-starter@0.0.1 lint-js /Users/rcombs/Documents/dev/clay-starter/app
> eslint . --cache app.js components search services sites
> clay-starter@0.0.1 lint-css /Users/rcombs/Documents/dev/clay-starter/app
> (for d in styleguides/* ; do stylelint --max-warnings 0 "$d/components/*.css" || exit; done)