### PR TITLE
Feature: Add Custom Carousel Component

### DIFF
--- a/app/components/carousel/bootstrap.yml
+++ b/app/components/carousel/bootstrap.yml
@@ -1,0 +1,4 @@
+_components:
+  carousel:
+    images: []
+

--- a/app/components/carousel/schema.yml
+++ b/app/components/carousel/schema.yml
@@ -1,0 +1,28 @@
+_description: |
+  A simple carousel.
+
+images:
+  _label: Images
+  _has:
+    input: complex-list
+    props:
+      -
+        prop: imgSrc
+        _label: Image URL
+        _has:
+          input: text
+          type: url
+          validate:
+            required: true
+      -
+        prop: altText
+        _label: Alt Text
+        _has:
+          input: text
+          type: text
+          validate:
+            required: true
+_groups:
+  settings:
+    fields:
+      - images

--- a/app/components/carousel/template.hbs
+++ b/app/components/carousel/template.hbs
@@ -1,0 +1,26 @@
+<div data-uri="{{ default _ref _self }}" class="{{ componentVariation }}" data-editable="settings">
+  <ul class="images">
+    {{#each images}}
+      <li class="image fade">
+        <img src={{ imgSrc }} alt={{ altTex }}>
+      </li>
+    {{/each}}
+  </ul>
+  <button class="prev" onclick=" changeSlide('prev')">&lang;</button>
+  <button class="next" onclick="changeSlide()">&rang;</button>
+</div>
+<script>
+  const imageList = [...document.querySelectorAll('.image')];
+  let currentSlide = 0
+  imageList[currentSlide].classList.add('active');
+
+  function changeSlide(action) {
+    imageList[currentSlide].classList.remove('active');
+    if (action === 'prev') {
+      currentSlide = !currentSlide ? imageList.length - 1 : --currentSlide;
+    } else {
+      currentSlide = currentSlide < imageList.length - 1 ? ++currentSlide : 0;
+    }
+    imageList[currentSlide].classList.add('active');
+  }
+</script>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -5637,7 +5637,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5655,11 +5656,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5672,15 +5675,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5783,7 +5789,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5793,6 +5800,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5805,17 +5813,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5832,6 +5843,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5904,7 +5916,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5914,6 +5927,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5989,7 +6003,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6019,6 +6034,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6036,6 +6052,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6074,11 +6091,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/app/styleguides/_default/components/carousel.css
+++ b/app/styleguides/_default/components/carousel.css
@@ -1,0 +1,60 @@
+@keyframes fade {
+  from {
+    opacity: 0.4;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.carousel {
+  position: relative;
+}
+
+.fade {
+  animation-name: fade;
+  animation-duration: 1.5s;
+}
+
+.images {
+  display: flex;
+  list-style: none;
+  padding: 0 40px;
+}
+
+.image {
+  display: none;
+}
+
+.image.active {
+  display: block;
+}
+
+.next,
+.prev {
+  background: transparent;
+  border: none;
+  border-radius: 0 3px 3px 0;
+  color: black;
+  cursor: pointer;
+  font-size: 18px;
+  font-weight: bold;
+  margin-top: -22px;
+  padding: 16px;
+  position: absolute;
+  top: 50%;
+  transition: 0.6s ease;
+  user-select: none;
+  width: auto;
+}
+
+.next:hover,
+.prev:hover {
+  background-color: black;
+  opacity: 0.2;
+}
+
+.next {
+  border-radius: 3px 0 0 3px;
+  right: 0;
+}

--- a/bootstrap-starter-data/_components.yml
+++ b/bootstrap-starter-data/_components.yml
@@ -176,3 +176,17 @@ _components:
             _ref: /_components/paragraph/instances/new
         tags:
           _ref: /_components/tags/instances/sample
+
+  carousel:
+    instances:
+      new:
+        images: [
+          {
+            imgSrc: 'https://images.dog.ceo/breeds/corgi-cardigan/n02113186_6415.jpg',
+            altText: 'Corgi'
+          },
+          {
+            imgSrc: 'https://images.dog.ceo/breeds/corgi-cardigan/n02113186_6300.jpg',
+            altText: 'Another Corgi'
+          }
+        ]

--- a/bootstrap-starter-data/_pages.yml
+++ b/bootstrap-starter-data/_pages.yml
@@ -3,6 +3,7 @@ _pages:
     layout: /_layouts/layout/instances/article
     main:
       - /_components/article/instances/sample
+      - /_components/carousel/instances/new
     head: []
   new-standard:
     layout: /_layouts/layout/instances/article


### PR DESCRIPTION
### Description

Add a Customizable Carousel Component

### Testing Steps
- Follow the [setup](https://github.com/clay/clay-starter#setup) found in the documentation of this repo
- Go to the [Sample Article](http://localhost/_pages/sample-article.html) and scroll to the bottom of the page
- Pressing the buttons at both side of the current image should change it back and forth
- Press `SHIFT + CLAY` to enter the editing view
- At the top-left corner click on `Edit Page` and then select `Edit Layout`
- Hover over the current carousel and click on `Carousel Setting`
- Add as many images as you'd like and press `ESC` or click on the Save button at the top-right corner of the current modal
- At the top-left corner click on `Edit Layout` and then select `View Page` the added images should be present in the current carousel
